### PR TITLE
config.css: fix for firefox 115 ESR / 116 page width

### DIFF
--- a/profile/chrome/utils/aboutconfig/config.css
+++ b/profile/chrome/utils/aboutconfig/config.css
@@ -47,3 +47,7 @@
 #configTreeBody::-moz-tree-cell-text(locked) {
   font-style: italic;
 }
+
+.deck-selected {
+  max-width: 100vw;
+}


### PR DESCRIPTION
As shown [here in issue #10](https://github.com/earthlng/aboutconfig/issues/10#issuecomment-1694683785), in FF 116 the about:config menu shoots way off the end of the screen to the right.

I know FF 117 is out now, but I thought I would at least submit a pull request anyway, since this problem also impacts FF 115 ESR. This way, people know there is a fix if they are still on those versions. I don't think it'd hurt anything in FF 117, either.

I use this fix on my own computers.